### PR TITLE
Fixed #296

### DIFF
--- a/src/lib/system/media/provider/YoutubeMediaProvider.class.php
+++ b/src/lib/system/media/provider/YoutubeMediaProvider.class.php
@@ -69,7 +69,7 @@ class YoutubeMediaProvider extends AbstractMediaProvider {
 	 */
 	protected function getEmbedInformation($source, $maxwidth = 0, $maxheight = 0) {
 		// we have to let the escaping out as that is done in Regex itself, if we escape here, the result will be a wrong one
-		$regex = '^https://(?:www\.youtube\.com|youtu\.be)/(?:watch\?v=)?([\w-]+)((?:\?|&|&amp;)\w+=[\w\d]+(?:(?:\?|&|&amp;)\w+=[\w\d]+)*)?';
+		$regex = '^https://(?:www\.youtube\.com|youtu\.be)/(?:watch\?v=)?([\w-_]+)((?:\?|&|&amp;)\w+=[\w\d]+(?:(?:\?|&|&amp;)\w+=[\w\d]+)*)?';
 		$regexObj = new Regex($regex);
 		if (!$regexObj->match($source, true)) {
 			throw new SystemException('invalid source', 0, 'The given source URL is not a valid Youtube share link.');


### PR DESCRIPTION
- Youtube videos with an underscore are now accepted by the media block
